### PR TITLE
Fix Radio Spawn

### DIFF
--- a/CharacterBody3D.gd
+++ b/CharacterBody3D.gd
@@ -79,7 +79,6 @@ func _physics_process(delta):
 
 	if velocity.y < peak_fall_speed:
 		peak_fall_speed = velocity.y  
-		print("peak: ", peak_fall_speed)
 	if peak_fall_speed < -3 and is_on_floor():  
 				$LandingAudio.play()
 				peak_fall_speed = 0.0  

--- a/chunk.gd
+++ b/chunk.gd
@@ -124,5 +124,7 @@ func spawn_structure(position: Vector3, rotation_y: float, scale_factor: float):
 	ruins.call_deferred("_set_transform", position, rotation_y, scale_factor)
 	if randi() % 100 < 100:  # 1% chance
 		var radio = preload("res://src/object/radio.tscn").instantiate()
-		ruins.add_child(radio)
-		radio.call_deferred("_set_scale", 0.1)
+		add_child(radio)
+		radio.call_deferred("set_global_position", position)
+		radio.call_deferred("freeze")
+		# radio.call_deferred("_set_scale", 0.1)

--- a/chunk.gd
+++ b/chunk.gd
@@ -107,7 +107,7 @@ func create_chunk(pos):
 
 	terrain.chunk_list.append(cName)
 
-	if randi() % 500 < 1:		
+	if randi() % 200 < 1:		
 		var random_rotation = randf() * 360.0
 		var random_scale = 2 + randf() * 1.5
 		spawn_structure(position + Vector3(terrain.chunk_size * 0.5, 4 * random_scale, terrain.chunk_size * 0.5), 
@@ -123,8 +123,4 @@ func spawn_structure(position: Vector3, rotation_y: float, scale_factor: float):
 	# Use a single deferred call to set position, rotation, and scale
 	ruins.call_deferred("_set_transform", position, rotation_y, scale_factor)
 	if randi() % 100 < 100:  # 1% chance
-		var radio = preload("res://src/object/radio.tscn").instantiate()
-		add_child(radio)
-		radio.call_deferred("set_global_position", position)
-		radio.call_deferred("freeze")
-		# radio.call_deferred("_set_scale", 0.1)
+		ruins.spawn_loot(position)

--- a/main.tscn
+++ b/main.tscn
@@ -97,7 +97,7 @@ shadow_opacity = 0.75
 shadow_blur = 5.0
 
 [node name="Moon" type="DirectionalLight3D" parent="Environment"]
-transform = Transform3D(0.950518, 0, -0.310667, 0.307638, -0.13932, 0.941248, -0.0432821, -0.990247, -0.132426, 0, 0, 0)
+transform = Transform3D(0.950518, 0, -0.310667, 0.307638, -0.13932, 0.941248, -0.043282, -0.990247, -0.132426, 0, 0, 0)
 rotation_order = 4
 light_color = Color(1, 1, 0.6, 1)
 light_energy = 0.1

--- a/src/object/radio.gd
+++ b/src/object/radio.gd
@@ -1,5 +1,7 @@
 extends Node3D
 
+@onready var body = $Mesh1_Mesh1_108
+
 
 func _set_transform(position: Vector3, rotation_y: float, scale_factor: float):
 	global_transform.origin = position
@@ -9,3 +11,9 @@ func _set_transform(position: Vector3, rotation_y: float, scale_factor: float):
 
 func _set_scale(scale_factor: float):
 	scale = Vector3(scale_factor, scale_factor, scale_factor)
+
+func freeze():
+	body.freeze = true
+	
+func unfreeze():
+	body.freeze = false

--- a/src/structure/ruins/ruins_01.gd
+++ b/src/structure/ruins/ruins_01.gd
@@ -1,7 +1,20 @@
 extends Node3D
 
+var radio: Node3D
+@onready var detection_area: Area3D = $DetectionArea
+
 
 func _set_transform(position: Vector3, rotation_y: float, scale_factor: float):
 	global_transform.origin = position
 	rotation_degrees.y = rotation_y
 	scale *= Vector3(scale_factor, scale_factor, scale_factor)
+
+func spawn_loot(position: Vector3):
+	radio = preload("res://src/object/radio.tscn").instantiate()
+	get_parent().add_child(radio)
+	radio.call_deferred("set_global_position", position)
+	radio.call_deferred("freeze")
+
+func _on_body_entered(body: Node3D) -> void:
+	if radio:
+		radio.unfreeze()

--- a/src/structure/ruins/ruins_01.tscn
+++ b/src/structure/ruins/ruins_01.tscn
@@ -1,7 +1,16 @@
-[gd_scene load_steps=3 format=3 uid="uid://hxqvvv5elegq"]
+[gd_scene load_steps=6 format=3 uid="uid://hxqvvv5elegq"]
 
 [ext_resource type="PackedScene" uid="uid://bxi6whsespwpy" path="res://texture/structure/ruins/ruins01.fbx" id="1_n4w2k"]
 [ext_resource type="Script" path="res://src/structure/ruins/ruins_01.gd" id="2_5e32q"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_fs73w"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_e51ca"]
+transparency = 1
+albedo_color = Color(1, 1, 1, 0.517647)
+
+[sub_resource type="BoxMesh" id="BoxMesh_vm5i1"]
+material = SubResource("StandardMaterial3D_e51ca")
 
 [node name="ruins01" instance=ExtResource("1_n4w2k")]
 transform = Transform3D(10, 0, 0, 0, 10, 0, 0, 0, 10, 0, 5.6, 0)
@@ -9,3 +18,16 @@ script = ExtResource("2_5e32q")
 
 [node name="StaticBody3D" parent="Mesh1" index="0"]
 collision_layer = 2
+
+[node name="DetectionArea" type="Area3D" parent="." index="1"]
+transform = Transform3D(1.75, 0, 0, 0, 1.75, 0, 0, 0, 1.75, 0, 0, 0)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="DetectionArea" index="0"]
+shape = SubResource("BoxShape3D_fs73w")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="DetectionArea" index="1"]
+mesh = SubResource("BoxMesh_vm5i1")
+skeleton = NodePath("../..")
+
+[connection signal="area_entered" from="DetectionArea" to="." method="_on_area_entered"]
+[connection signal="body_entered" from="DetectionArea" to="." method="_on_body_entered"]

--- a/terrain.gd
+++ b/terrain.gd
@@ -102,7 +102,7 @@ func create_raycast():
 	player.add_child(ray)
 
 func _on_chunk_change():
-	print("[LOG] - Another Chunk")
+	# print("[LOG] - Another Chunk")
 	pass
 
 func _on_map_ready():


### PR DESCRIPTION
## Changes
- Ruins now spawn in with an `Area3D` called `DetectionArea` that can be used to detect when a play enters the ruins.
- Radio spawn in with `freeze = true` meaning its not affected by gravity
- Entering the Ruin's `DetectionArea` causes `freeze` to be `false`, meaning the radio is affected by physics

## Notes
I put a big white semi-transparent mesh around the collision area for debug. It can be disabled from the scene `ruin_01.tscn`
![image](https://github.com/user-attachments/assets/45625d08-ec12-4ce9-a0b2-2cf7d66fddbd)
